### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/src/ui/dashboard/js/pages/logs.js
+++ b/src/ui/dashboard/js/pages/logs.js
@@ -188,15 +188,53 @@ function searchLogs(query) {
     const text = line.textContent.toLowerCase();
     if (text.includes(lowerQuery)) {
       line.style.display = '';
-      // Highlight matching text
+      // Highlight matching text without reinterpreting DOM text as HTML
       line.querySelectorAll('.message').forEach((msg) => {
         const content = msg.textContent;
-        if (content.toLowerCase().includes(lowerQuery)) {
-          const regex = new RegExp(`(${query})`, 'gi');
-          msg.innerHTML = content.replace(
-            regex,
-            '<mark style="background: var(--color-warning-muted); color: var(--color-warning);">$1</mark>',
+        const lowerContent = content.toLowerCase();
+        if (!lowerContent.includes(lowerQuery)) {
+          return;
+        }
+
+        // Clear existing content and rebuild with <mark> elements for matches
+        msg.textContent = '';
+
+        const markStyle =
+          'background: var(--color-warning-muted); color: var(--color-warning);';
+        let currentIndex = 0;
+        const queryLength = query.length;
+
+        while (true) {
+          const matchIndex = lowerContent.indexOf(lowerQuery, currentIndex);
+          if (matchIndex === -1) {
+            // Append remaining text (if any)
+            if (currentIndex < content.length) {
+              msg.appendChild(
+                document.createTextNode(content.slice(currentIndex)),
+              );
+            }
+            break;
+          }
+
+          // Append text before the match
+          if (matchIndex > currentIndex) {
+            msg.appendChild(
+              document.createTextNode(
+                content.slice(currentIndex, matchIndex),
+              ),
+            );
+          }
+
+          // Append the matched text inside a <mark> element
+          const markEl = document.createElement('mark');
+          markEl.setAttribute('style', markStyle);
+          markEl.textContent = content.slice(
+            matchIndex,
+            matchIndex + queryLength,
           );
+          msg.appendChild(markEl);
+
+          currentIndex = matchIndex + queryLength;
         }
       });
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/AG064/ag-claw/security/code-scanning/22](https://github.com/AG064/ag-claw/security/code-scanning/22)

In general, the fix is to avoid taking text from the DOM and then injecting it back into the DOM as HTML. Instead, keep working with text nodes and DOM nodes directly, or ensure any interpolated values are HTML-escaped before assigning to `innerHTML`.

For this specific case, we need to highlight matching substrings in `.message` elements without using `innerHTML = ...` on tainted text. The best way to preserve existing behavior (including the `<mark>` tags for highlights) without changing external functionality is:

1. For each `.message` element that matches the query:
   - Read the original text via `msg.textContent`.
   - Clear the element’s content.
   - Walk through the text, finding all case-insensitive matches of `query`.
   - Append non-matching segments as text nodes.
   - Append matching segments as `<mark>` elements with the same inline styles as currently used.
2. This way, only the `<mark>` tags are created as elements, and the original text (including the matched substring) is inserted via `textContent`, not interpreted as markup. We eliminate use of `innerHTML` on untrusted text while keeping UI and behavior the same.

We only need to modify `searchLogs` in `src/ui/dashboard/js/pages/logs.js`, specifically the block around lines 192–199. No new imports are required; we rely on standard DOM APIs (`document.createElement`, `document.createTextNode`, etc.). The rest of the file remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
