### PR TITLE
fix(ci): restore proper vulnerability checks in dependency-scan

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -47,12 +47,24 @@ jobs:
 
       - name: Check for critical vulnerabilities
         run: |
-          echo "=== Debug ==="
           if [ -f trivy-dependencies.sarif ]; then
-            echo "File exists, size: $(wc -c < trivy-dependencies.sarif)"
+            COUNT=$(jq '.runs[0].results | length' trivy-dependencies.sarif 2>/dev/null || echo "0")
+            echo "Trivy found $COUNT vulnerabilities"
+            if [ "$COUNT" -gt 0 ]; then
+              echo "FAIL: Critical/high vulnerabilities found in dependencies"
+              exit 1
+            fi
           else
-            echo "File does not exist"
+            echo "No trivy results file found - skipping"
           fi
-          echo "Listing all files in current dir:"
-          ls -la *.sarif 2>/dev/null || echo "No sarif files"
-          echo "=== End Debug ==="
+          echo "PASS: No critical/high vulnerabilities found"
+
+      - name: Check npm audit results
+        run: |
+          RESULT=$(npm audit --audit-level=high 2>&1)
+          echo "$RESULT"
+          if echo "$RESULT" | grep -qP '[1-9]\d*(?=\s+vulnerabilit)'; then
+            echo "FAIL: npm audit found high/critical issues"
+            exit 1
+          fi
+          echo "PASS: npm audit passed".


### PR DESCRIPTION
Restore proper Trivy and npm audit checks in dependency-scan workflow. Previously debug-only step was added to bypass failures - now proper checks are restored with correct logic.