### PR TITLE
docs: add private security fixes practice to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,3 +14,5 @@
 Feedback mechanism in-code: users should be able to submit bug reports and feature requests from within the running application, not just through GitHub.
 
 Russian language: UI strings, onboarding, and docs to support the Russian-speaking user base.
+
+Private security fixes: establish a practice for handling non-public security vulnerabilities that may never be publicly released or include legally restricted material.


### PR DESCRIPTION
Add note about establishing practice for non-public security fixes.