### PR TITLE
fix: remove last lint warning

### DIFF
--- a/src/channels/webchat.ts
+++ b/src/channels/webchat.ts
@@ -5,14 +5,14 @@
  * real-time streaming responses.
  */
 
+import { randomBytes } from 'crypto';
+
 import {
   type FeatureModule,
   type FeatureContext,
   type FeatureMeta,
   type HealthStatus,
 } from '../core/plugin-loader';
-
-import { randomBytes } from 'crypto';
 
 function secureId(length = 8): string {
   return randomBytes(length).toString('hex');


### PR DESCRIPTION
Fix import order warning in webchat.ts. Zero warnings now.