### PR TITLE
test: add fast-check fuzz tests for validation and allowlist functions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [development, main]
   pull_request:
     branches: [development, main]
+  schedule:
+    - cron: "0 9 * * *" # Daily at 09:00 UTC
 
 permissions:
   contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,14 @@
-# Security Vulnerabilities — Known Issues
+# Security Policy
+
+## Reporting Vulnerabilities
+
+To report a security vulnerability, contact the maintainer directly:
+
+- Email: agdroke064@gmail.com
+- Include a description of the issue and steps to reproduce if possible
+- Allow time for assessment and patch development before public disclosure
+
+## Known Issues
 
 ## Active
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-jest": "^29.15.1",
         "eslint-plugin-unicorn": "^50.0.1",
+        "fast-check": "^4.8.0",
         "globals": "^17.4.0",
         "husky": "^9.1.7",
         "jest": "^30.4.1",
@@ -5163,6 +5164,46 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-copy": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jest": "^29.15.1",
     "eslint-plugin-unicorn": "^50.0.1",
+    "fast-check": "^4.8.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",
     "jest": "^30.4.1",

--- a/tests/fuzz/validation.fuzz.test.ts
+++ b/tests/fuzz/validation.fuzz.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Fuzz tests for input validation functions using fast-check.
+ * These tests apply dynamic analysis by generating random inputs
+ * to find edge cases and potential crashes.
+ */
+
+import { test } from '@jest/globals';
+import * as fc from 'fast-check';
+
+import { AllowlistManager } from '../../src/security/allowlists';
+import { isValidUrl, isSafePath, isEmail } from '../../src/utils/validation';
+
+test('Fuzz: isValidUrl should not throw on any string input', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      expect(() => isValidUrl(value)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isValidUrl should not throw on empty string', () => {
+  expect(() => isValidUrl('')).not.toThrow();
+});
+
+test('Fuzz: isValidUrl should return boolean for all inputs', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      const result = isValidUrl(value);
+      expect(typeof result).toBe('boolean');
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isSafePath should not throw on any string input', () => {
+  fc.assert(
+    fc.property(fc.string(), (path) => {
+      expect(() => isSafePath(path)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isSafePath should not throw on nullish values', () => {
+  expect(() => isSafePath(null)).not.toThrow();
+  expect(() => isSafePath(undefined)).not.toThrow();
+});
+
+test('Fuzz: isSafePath should not throw on empty string', () => {
+  expect(() => isSafePath('')).not.toThrow();
+});
+
+test('Fuzz: isSafePath should handle path traversal attempts safely', () => {
+  const traversalAttempts = [
+    '../../../etc/passwd',
+    '..\\..\\..\\windows\\system32',
+    '${ENV_VAR}',
+    '$(command)',
+    '`whoami`',
+    '\0null',
+    '\nnewlines',
+    '\rreturns',
+    '\ttabs',
+    '\x00bytes',
+  ];
+  traversalAttempts.forEach((path) => {
+    expect(() => isSafePath(path)).not.toThrow();
+  });
+});
+
+test('Fuzz: isSafePath should return boolean for all inputs', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      const result = isSafePath(value);
+      expect(typeof result).toBe('boolean');
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isEmail should not throw on any string input', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      expect(() => isEmail(value)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isEmail should not throw on empty string', () => {
+  expect(() => isEmail('')).not.toThrow();
+});
+
+test('Fuzz: isEmail should return boolean for all inputs', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      const result = isEmail(value);
+      expect(typeof result).toBe('boolean');
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: isEmail should handle valid email patterns', () => {
+  const validEmails = [
+    'test@example.com',
+    'user.name@domain.org',
+    'user+tag@domain.co.uk',
+    'a@b.co',
+  ];
+  validEmails.forEach((email) => {
+    expect(isEmail(email)).toBe(true);
+  });
+});
+
+test('Fuzz: AllowlistManager should not throw on any string input to isCommandAllowed', () => {
+  const allowlist = new AllowlistManager();
+  allowlist.loadConfig({
+    commands: ['echo', 'ls', 'cat'],
+    paths: ['/home/*/documents', '/tmp/*'],
+    hosts: ['api.example.com', '*.github.com'],
+  });
+  fc.assert(
+    fc.property(fc.string(), (cmd) => {
+      expect(() => allowlist.isCommandAllowed(cmd)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: AllowlistManager should not throw on any string input to isPathAllowed', () => {
+  const allowlist = new AllowlistManager();
+  allowlist.loadConfig({
+    commands: ['echo', 'ls', 'cat'],
+    paths: ['/home/*/documents', '/tmp/*'],
+    hosts: ['api.example.com', '*.github.com'],
+  });
+  fc.assert(
+    fc.property(fc.string(), (path) => {
+      expect(() => allowlist.isPathAllowed(path)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: AllowlistManager should not throw on any string input to isHostAllowed', () => {
+  const allowlist = new AllowlistManager();
+  allowlist.loadConfig({
+    commands: ['echo', 'ls', 'cat'],
+    paths: ['/home/*/documents', '/tmp/*'],
+    hosts: ['api.example.com', '*.github.com'],
+  });
+  fc.assert(
+    fc.property(fc.string(), (host) => {
+      expect(() => allowlist.isHostAllowed(host)).not.toThrow();
+    }),
+    { numRuns: 10000 },
+  );
+});
+
+test('Fuzz: AllowlistManager should handle glob patterns safely', () => {
+  const globAttempts = ['*', '**', '???', '[a-z]', '{a,b,c}', '*/../*', '/**/*', '/*/*/*'];
+  globAttempts.forEach((pattern) => {
+    const testAllowlist = new AllowlistManager();
+    testAllowlist.loadConfig({
+      commands: [pattern],
+      paths: [],
+      hosts: [],
+    });
+    expect(() => testAllowlist.isCommandAllowed('anything')).not.toThrow();
+  });
+});
+
+test('Fuzz: AllowlistManager should not throw on empty config', () => {
+  const allowlist = new AllowlistManager();
+  expect(() => allowlist.loadConfig({ commands: [], paths: [], hosts: [] })).not.toThrow();
+});
+
+test('Fuzz: AllowlistManager should not throw on malformed configs', () => {
+  const malformedConfigs = [
+    { commands: null, paths: [], hosts: [] },
+    { commands: undefined, paths: [], hosts: [] },
+    { commands: 'not-an-array', paths: [], hosts: [] },
+    {},
+  ];
+  malformedConfigs.forEach((config) => {
+    const allowlist = new AllowlistManager();
+    expect(() => allowlist.loadConfig(config as any)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Add fast-check fuzz tests covering isValidUrl, isSafePath, isEmail and AllowlistManager for dynamic analysis criterion.