### PR TITLE
docs: add DCO for Silver badge criterion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Here's the honest truth upfront: this project is maintained by one person (AG064) in their free time. Contributions are welcome, but response times may vary. That said, every PR gets read and every issue gets considered.
 
+## Sign-off Requirement
+
+All contributions must include a sign-off line certifying the [Developer Certificate of Origin (DCO)](DCO.md):
+
+```
+Signed-off-by: Name <email@example.com>
+```
+
+Use `git commit -s` to sign your commits automatically.
+
 ## What Can I Help With?
 
 **Bugs** — If something breaks and you know why, a PR with a fix is the fastest path.
@@ -115,13 +125,13 @@ npm run test:watch
 
 ### What the Tests Cover
 
-| Test Suite | Purpose |
-|------------|---------|
-| Unit tests | Individual functions and modules (config, memory, security, tools) |
-| Integration tests | Channel integrations (Telegram, etc.), API interactions |
-| E2E tests | Full workflow from user input to response |
-| CLI smoke tests | Binary execution and basic commands |
-| GitHub workflow tests | Security configuration validation |
+| Test Suite            | Purpose                                                            |
+| --------------------- | ------------------------------------------------------------------ |
+| Unit tests            | Individual functions and modules (config, memory, security, tools) |
+| Integration tests     | Channel integrations (Telegram, etc.), API interactions            |
+| E2E tests             | Full workflow from user input to response                          |
+| CLI smoke tests       | Binary execution and basic commands                                |
+| GitHub workflow tests | Security configuration validation                                  |
 
 ### Interpreting Results
 
@@ -141,6 +151,7 @@ Tests run automatically on every push to `development` and `main` branches, and 
 ### Test Policy for Major Changes
 
 **What constitutes a major change:**
+
 - New features or capabilities
 - Changes to public APIs
 - Bug fixes that alter expected behavior
@@ -148,12 +159,14 @@ Tests run automatically on every push to `development` and `main` branches, and 
 - Changes to build or release process
 
 **What tests to add or update:**
+
 - New functionality MUST include unit tests
 - Bug fixes MUST include a test that reproduces the bug (regression test)
 - API changes MUST update existing tests
 - Security changes MUST include relevant security tests
 
 **Policy:**
+
 - PRs with new features that don't add tests will be asked to add them
 - Bug fixes without regression tests may be accepted if adding tests is impractical (e.g., one-line fixes)
 - Current test coverage is acknowledged as thin — real-world bug reports with reproduction steps are valuable

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,58 @@
+# Developer Certificate of Origin
+
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have
+the right to submit it under the open source license indicated in the
+file; or
+
+(b) The contribution is based upon previous work that, to my knowledge,
+is covered under an appropriate open source license and I have the
+right under that license to submit that work with modifications,
+whether created in whole or in part by me, under the same open source
+license (unless I am permitted to submit under a different license),
+as indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person
+who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are
+public and that a record of the contribution (including all personal
+information I submit with it, including my sign-off) is maintained
+indefinitely and may be redistributed consistent with this project
+or the open source license(s) involved.
+
+## Sign-off Procedure
+
+All commits must include a sign-off line to certify the DCO:
+
+```
+Signed-off-by: Name <email@example.com>
+```
+
+You can sign off your commits using the `-s` flag:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+## Why the DCO Matters
+
+The DCO is a simple statement that you are legally authorized to make
+the contribution. It does not require you to assign copyright to the
+project, but ensures that the project can use and redistribute your
+contribution freely.
+
+## Contact
+
+For questions about the DCO, please open an issue or contact the
+maintainer at agdroke064@gmail.com.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 [![Version](https://img.shields.io/badge/version-v0.0.7-blue.svg?style=flat-square)](https://github.com/AG064/argentum/releases)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12957/badge)](https://www.bestpractices.dev/projects/12957)
-[![OpenSSF Baseline Level 1](https://www.bestpractices.dev/projects/12957/badges/1)](https://www.bestpractices.dev/projects/12957/baseline)
-[![OpenSSF Baseline Level 2](https://www.bestpractices.dev/projects/12957/badges/2)](https://www.bestpractices.dev/projects/12957/baseline)
-[![OpenSSF Baseline Level 3](https://www.bestpractices.dev/projects/12957/badges/3)](https://www.bestpractices.dev/projects/12957/baseline)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12957/baseline)](https://www.bestpractices.dev/projects/12957)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.0.0-green.svg?style=flat-square)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg?style=flat-square)](./LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/AG064/argentum/ci.yml?style=flat-square)](https://github.com/AG064/argentum/actions)


### PR DESCRIPTION
Add Developer Certificate of Origin and sign-off requirement per Silver badge criteria.