### PR TITLE
docs: add i18n infrastructure to v0.1.0 roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,14 @@ Argentum v0.0.7 is released and functional. The project is actively maintained.
 
 ### v0.1.0 (Next 3-6 months)
 
-- In-app feedback system — bug reports and feature requests from within the desktop app
-- Russian language UI and documentation
-- Estonian language UI and documentation
+- **Internationalization (i18n) infrastructure** — enable localization for any language
+  - Extract all user-facing strings to locale files (en.json as base)
+  - Implement t('key') translation function used throughout codebase
+  - Support text direction (LTR/RTL) via CSS logical properties
+  - Number/date formatting via Intl API (not hardcoded formats)
+  - Language picker in settings and onboarding
+- **Russian language UI and documentation**
+- **Estonian language UI and documentation**
 - Test suite fixes (Jest/ESM configuration)
 - Improved test coverage (expand to more code branches)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,10 @@ Argentum v0.0.7 is released and functional. The project is actively maintained.
   - Accent color picker (replace default red with any color; logo stays unchanged)
   - Error/warning text styling independent of color (icons + text, not color alone)
 - **In-app update mechanism** — check for and apply updates without manual reinstall
+- **Interactive help button (?)** — context-sensitive help tooltip linked to relevant docs section; appears on hover/focus near each major UI element
+  - Clicking ? opens relevant documentation page in browser
+  - Tooltip text explains what the element does and how to use it
+  - ? button visible in onboarding flow and settings
 - **Accessibility documentation updates** — new menus and features include keyboard shortcuts and ARIA attributes in each release
 
 ### Future (6-12 months)


### PR DESCRIPTION
Add i18n infrastructure (locale files, t function, RTL support, Intl API) to v0.1.0 roadmap before Russian/Estonian localization.