### PR TITLE
docs: replace untrusted Cosign installer guidance

### DIFF
--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -74,8 +74,8 @@ Expected output: `<filename>: OK` for each file.
 ### Sigstore Cosign Verification (for signed bundles)
 
 ```bash
-# Install cosign if needed
-curl -sSL https://solitario.com/install.sh | sh
+# Install cosign using an official method if needed:
+# https://docs.sigstore.dev/cosign/system_config/installation/
 
 # Verify a binary
 cosign verify-blob \
@@ -87,9 +87,9 @@ cosign verify-blob \
 
 ### What Each Verification Proves
 
-| Method | Proves |
-|--------|--------|
-| SHA256 | File content matches released version (integrity) |
+| Method   | Proves                                                         |
+| -------- | -------------------------------------------------------------- |
+| SHA256   | File content matches released version (integrity)              |
 | Sigstore | Binary was built by GitHub Actions in this repo (authenticity) |
 
 ## Notes


### PR DESCRIPTION
### Motivation
- Remove the insecure, unauthenticated third-party `curl -sSL https://solitario.com/install.sh | sh` instruction from the release verification docs because it permits arbitrary remote code execution and undermines supply-chain verification.

### Description
- In `docs/releases/v0.0.7.md` replaced the `curl | sh` Cosign installer invocation with a pointer to the official Sigstore Cosign installation documentation while preserving the existing `cosign verify-blob` verification example.

### Testing
- Ran `git diff --check`, an `rg` search for the unsafe installer pattern, and `npx prettier --check docs/releases/v0.0.7.md`, all of which passed; an attempt to `curl -fsSIL https://docs.sigstore.dev/cosign/system_config/installation/` to validate the target returned HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e40a6cf14832081bf1235d8282fc6)