### PR TITLE
fix(ci): pin privileged release actions to immutable commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -75,7 +75,7 @@ jobs:
           sha256sum argentum-v${{ steps.package.outputs.version }}-linux-x64 argentum-cli-v${{ steps.package.outputs.version }}-win-x64.exe argentum-v${{ steps.package.outputs.version }}-macos-x64 > SHA256SUMS-portable.txt
 
       - name: Upload portable artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: argentum-portable-binaries
           path: |
@@ -84,7 +84,7 @@ jobs:
             artifacts/release/argentum-v*-macos-x64
             artifacts/release/SHA256SUMS-portable.txt
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: Argentum ${{ github.ref_name }}
@@ -110,16 +110,16 @@ jobs:
       ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v4
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3
 
       - name: Create local.properties
         run: |
@@ -199,7 +199,7 @@ jobs:
           ls -la artifacts/android
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: argentum-android-apk
           path: artifacts/android/argentum-${{ steps.package.outputs.version }}-android.apk
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload APK to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca # v2
         with:
           files: |
             artifacts/android/argentum-${{ steps.package.outputs.version }}-android.apk

--- a/tests/github-security-workflows.test.ts
+++ b/tests/github-security-workflows.test.ts
@@ -42,6 +42,18 @@ describe('GitHub security workflow baseline', () => {
     }
   });
 
+  test('privileged release workflow pins third-party actions to immutable commits', () => {
+    const release = workflow('release.yml');
+    const actionReferences = [...release.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map(
+      (match) => match[1],
+    );
+
+    expect(actionReferences).not.toHaveLength(0);
+    for (const reference of actionReferences) {
+      expect(reference).toMatch(/^[^@]+@[0-9a-f]{40}$/);
+    }
+  });
+
   test('desktop workflow builds Tauri artifacts for each supported platform', () => {
     const desktop = workflow('desktop.yml');
 
@@ -59,14 +71,18 @@ describe('GitHub security workflow baseline', () => {
     expect(desktop).toContain('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a');
     expect(desktop).toContain('src/desktop/target/release/bundle/**/*');
     expect(desktop).toContain('src/desktop/target/*/release/bundle/**/*');
-    expect(desktop).toContain('softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca');
+    expect(desktop).toContain(
+      'softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca',
+    );
   });
 
   test('OpenSSF Scorecard uploads SARIF results to GitHub code scanning', () => {
     const scorecard = workflow('scorecard.yml');
 
     expect(scorecard).toContain('ossf/scorecard-action@af76153369ae1eb1eaffc4118046b7fda9a8419e');
-    expect(scorecard).toContain('github/codeql-action/upload-sarif@0e150e40762c1253b364a04b0fc9f2cc14effff2');
+    expect(scorecard).toContain(
+      'github/codeql-action/upload-sarif@0e150e40762c1253b364a04b0fc9f2cc14effff2',
+    );
     expect(scorecard).toContain('category: scorecard');
   });
 });


### PR DESCRIPTION
### Motivation

- The release workflow executed privileged steps with `contents: write` while referencing third-party actions by mutable tags, which risks a supply-chain compromise of published artifacts. 
- The change restores reproducible, auditable action references and adds a guard to prevent future regressions in the privileged release job.

### Description

- Pin all third-party actions used in the `portable-binaries` and `android-apk` jobs in `.github/workflows/release.yml` to immutable 40-character commit SHAs while keeping human-readable version comments (e.g. `# v4`).
- Specific actions pinned include `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `softprops/action-gh-release`, `actions/setup-java`, and `android-actions/setup-android`.
- Add a regression test in `tests/github-security-workflows.test.ts` that scans `release.yml` for `uses:` references and asserts each one is pinned to a 40-character hexadecimal SHA.
- Minor formatting adjustments were applied to keep the tests consistent with the new assertion.

### Testing

- Ran `git diff --check` to validate whitespace and patch hygiene and it reported no problems.
- Ran `npm test -- --runInBand tests/github-security-workflows.test.ts` and the test suite completed successfully with `1` test suite and `7` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e32e762b08320be33cce834172270)