### PR TITLE
fix: limit Android signing secrets to keystore decoding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,11 +104,6 @@ jobs:
     needs: portable-binaries
     permissions:
       contents: write
-    env:
-      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -125,8 +120,13 @@ jobs:
         run: |
           echo "sdk.dir=${ANDROID_HOME}" > android/local.properties
 
-      - name: Validate persistent Android signing identity
+      - name: Decode user keystore from secret
         shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
@@ -136,10 +136,6 @@ jobs:
               exit 1
             fi
           done
-
-      - name: Decode user keystore from secret
-        shell: bash
-        run: |
           cd android/app
           mkdir -p keystore
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > keystore/release.keystore


### PR DESCRIPTION
### Motivation
- The Android signing secrets were previously placed in the `android-apk` job-level `env`, which made them available to every step and third-party action in the job and expanded the release supply-chain blast radius. 
- Only the keystore decoding step actually needs the secret values, so the values should be scoped to that trusted shell step to reduce exposure. 

### Description
- Remove the job-level `env` block that exported `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and `ANDROID_KEY_PASSWORD` to the entire `android-apk` job. 
- Add the four Android signing secrets as an `env` block on the single shell step that validates and decodes the keystore (the step now named `Decode user keystore from secret`). 
- Combine the validation and decoding logic into the same trusted shell step so existence checks and keystore file creation run under the same scoped environment. 

### Testing
- Ran `git diff --check` to ensure no whitespace or patch issues were introduced and it returned clean. 
- Parsed and asserted the workflow YAML structure with a Ruby script that verifies the `android-apk` job no longer has a job-level `env` and that the decode step alone contains the four secret env keys. 
- Confirmed the release workflow file parses and that no other steps inherit the Android signing secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2ecdd2d483208ab87136ddf58af3)